### PR TITLE
feat: añadir selector de rutas predefinidas con precarga automática d…

### DIFF
--- a/RUTAS-PREDEFINIDAS.md
+++ b/RUTAS-PREDEFINIDAS.md
@@ -1,0 +1,89 @@
+# 🚴 Rutas Predefinidas
+
+## Descripción
+
+Esta funcionalidad permite seleccionar rutas predefinidas en el formulario, que precargan automáticamente todos los datos de la salida (lugar, descripción, distancia, dificultad y plantilla).
+
+## ¿Cómo usar?
+
+1. En el formulario, verás un selector "🚴 Ruta Predefinida (opcional)" al principio
+2. Selecciona una ruta de la lista desplegable
+3. Los campos del formulario se rellenarán automáticamente con los datos de la ruta
+4. Puedes modificar cualquier campo después de seleccionar la ruta
+5. Ajusta la fecha y hora según tu salida
+6. Genera la imagen
+
+## Rutas incluidas por defecto
+
+### 🏔️ Rutas de Montaña
+- **Ruta del Cares** - Picos de Europa (12 km, moderada)
+- **Lagos de Covadonga** - Asturias (25 km, difícil)
+- **Naranjo de Bulnes** - Picos de Europa (18 km, difícil)
+- **Puerto de Pajares** - León-Asturias (35 km, difícil)
+
+### 🌊 Rutas Costeras
+- **Senda Costera** - Costa Asturiana (30 km, fácil)
+
+### 🏙️ Rutas Urbanas
+- **Ruta Urbana** - Centro Ciudad (15 km, fácil)
+
+## Añadir nuevas rutas
+
+Para añadir tus propias rutas, edita el archivo:
+
+```
+src/lib/rutasPredefinidas.ts
+```
+
+### Estructura de una ruta
+
+```typescript
+{
+  id: 'identificador-unico',           // ID único para la ruta
+  nombre: 'Nombre de la Ruta',         // Nombre que aparece en el selector
+  lugar: 'Lugar/Localidad',            // Ubicación de la ruta
+  descripcion: 'Descripción...',       // Descripción de la ruta (máx 200 caracteres)
+  distancia: '20 km',                  // Distancia (opcional)
+  dificultad: 'moderada',              // 'fácil', 'moderada' o 'difícil' (opcional)
+  plantilla: 'template1'               // 'template1', 'template2' o 'template3' (opcional)
+}
+```
+
+### Ejemplo de nueva ruta
+
+```typescript
+{
+  id: 'alto-angliru',
+  nombre: 'Alto del Angliru',
+  lugar: 'Asturias',
+  descripcion: 'Mítico puerto asturiano con rampas de más del 20%',
+  distancia: '12.5 km',
+  dificultad: 'difícil',
+  plantilla: 'template1'
+}
+```
+
+## Características
+
+✅ **Selector opcional** - No es obligatorio seleccionar una ruta
+✅ **Precarga automática** - Todos los campos se rellenan automáticamente
+✅ **Editable** - Puedes modificar los datos después de seleccionar
+✅ **Feedback visual** - El selector se ilumina en verde al seleccionar una ruta
+✅ **Fácil de extender** - Añade más rutas editando un solo archivo
+
+## Notas técnicas
+
+- Las rutas se definen en `src/lib/rutasPredefinidas.ts`
+- Los datos se duplican en el cliente (JavaScript) para evitar dependencias
+- Si añades rutas, recuerda actualizar ambas ubicaciones:
+  1. El array `rutasPredefinidas` (TypeScript)
+  2. El objeto `rutasData` en el script del componente
+- La plantilla seleccionada cambia el fondo de la imagen generada
+
+## Mejoras futuras
+
+- [ ] Cargar rutas desde una API o base de datos
+- [ ] Permitir a los usuarios crear y guardar sus propias rutas
+- [ ] Importar rutas desde archivos GPX
+- [ ] Filtrar rutas por dificultad o distancia
+- [ ] Añadir imágenes de preview de cada ruta

--- a/SYNOLOGY-DEPLOYMENT.md
+++ b/SYNOLOGY-DEPLOYMENT.md
@@ -60,7 +60,7 @@ El proyecto incluye:
    
    services:
      sportclub-img-gen:
-       image: jangelsalinas/sportclub-img-gen:latest
+       image: mullins85zgz/sportclub-img-gen:latest
        container_name: sportclub-img-gen
        restart: unless-stopped
        ports:

--- a/src/components/ImageForm.astro
+++ b/src/components/ImageForm.astro
@@ -2,12 +2,25 @@
 /**
  * Componente del formulario para capturar datos de la salida
  */
+import { rutasPredefinidas } from '../lib/rutasPredefinidas';
 ---
 
 <div class="card">
   <h2>📝 Datos de la Salida</h2>
   
   <form id="bikeForm">
+    <!-- Selector de Rutas Predefinidas (NUEVO) -->
+    <div class="form-group">
+      <label for="rutaPredefinida" class="form-label">🚴 Ruta Predefinida (opcional)</label>
+      <select id="rutaPredefinida" name="rutaPredefinida" class="form-select">
+        <option value="">-- Selecciona una ruta o crea una personalizada --</option>
+        {rutasPredefinidas.map((ruta) => (
+          <option value={ruta.id}>{ruta.nombre}</option>
+        ))}
+      </select>
+      <span class="form-hint">Selecciona una ruta para precargar los datos automáticamente</span>
+    </div>
+
     <!-- Fecha -->
     <div class="form-group">
       <label for="fecha" class="form-label required">Fecha</label>
@@ -192,6 +205,96 @@
         horaSelect.value = horaInput.value;
         horaSelect.style.display = 'block';
         horaInput.style.display = 'none';
+      }
+    });
+  }
+
+  // Manejo de rutas predefinidas
+  const rutaPredefinidaSelect = document.getElementById('rutaPredefinida') as HTMLSelectElement;
+  const lugarInput = document.getElementById('lugar') as HTMLInputElement;
+  const descripcionTextarea = document.getElementById('descripcion') as HTMLTextAreaElement;
+  const distanciaInput = document.getElementById('distancia') as HTMLInputElement;
+  const dificultadSelect = document.getElementById('dificultad') as HTMLSelectElement;
+  
+  // Datos de rutas predefinidas (deben coincidir con el archivo de configuración)
+  const rutasData = {
+    'cares': {
+      lugar: 'Picos de Europa',
+      descripcion: 'Espectacular ruta por la garganta del Cares con vistas impresionantes',
+      distancia: '12 km',
+      dificultad: 'moderada',
+      plantilla: 'template1'
+    },
+    'covadonga': {
+      lugar: 'Asturias',
+      descripcion: 'Ascenso a los míticos lagos con paisajes de montaña',
+      distancia: '25 km',
+      dificultad: 'difícil',
+      plantilla: 'template1'
+    },
+    'naranjo': {
+      lugar: 'Picos de Europa',
+      descripcion: 'Ruta hasta el emblemático Naranjo de Bulnes',
+      distancia: '18 km',
+      dificultad: 'difícil',
+      plantilla: 'template1'
+    },
+    'senda-costera': {
+      lugar: 'Costa Asturiana',
+      descripcion: 'Ruta panorámica por la costa con vistas al Cantábrico',
+      distancia: '30 km',
+      dificultad: 'fácil',
+      plantilla: 'template2'
+    },
+    'puerto-pajares': {
+      lugar: 'León - Asturias',
+      descripcion: 'Clásico puerto de montaña con alto desnivel',
+      distancia: '35 km',
+      dificultad: 'difícil',
+      plantilla: 'template1'
+    },
+    'ruta-urbana': {
+      lugar: 'Centro Ciudad',
+      descripcion: 'Paseo urbano por la ciudad y sus alrededores',
+      distancia: '15 km',
+      dificultad: 'fácil',
+      plantilla: 'template3'
+    }
+  };
+
+  if (rutaPredefinidaSelect) {
+    rutaPredefinidaSelect.addEventListener('change', () => {
+      const rutaId = rutaPredefinidaSelect.value as keyof typeof rutasData;
+      
+      if (rutaId && rutasData[rutaId]) {
+        const ruta = rutasData[rutaId];
+        
+        // Precargar datos en el formulario
+        if (lugarInput) lugarInput.value = ruta.lugar;
+        if (descripcionTextarea) {
+          descripcionTextarea.value = ruta.descripcion;
+          // Actualizar contador de caracteres
+          if (charCount) {
+            charCount.textContent = `${descripcionTextarea.value.length} / 200 caracteres`;
+          }
+        }
+        if (distanciaInput) distanciaInput.value = ruta.distancia || '';
+        if (dificultadSelect) dificultadSelect.value = ruta.dificultad || '';
+        
+        // Seleccionar plantilla si existe
+        const plantillaRadio = document.querySelector(`input[name="plantilla"][value="${ruta.plantilla}"]`) as HTMLInputElement;
+        if (plantillaRadio) {
+          plantillaRadio.checked = true;
+        }
+        
+        // Mostrar feedback visual
+        rutaPredefinidaSelect.style.borderColor = '#10b981';
+        setTimeout(() => {
+          rutaPredefinidaSelect.style.borderColor = '';
+        }, 1000);
+      } else {
+        // Si se deselecciona, limpiar solo si los campos están vacíos
+        // (para no borrar datos personalizados)
       }
     });
   }

--- a/src/lib/rutasPredefinidas.ts
+++ b/src/lib/rutasPredefinidas.ts
@@ -1,0 +1,71 @@
+/**
+ * Configuración de rutas predefinidas
+ * Estas rutas se pueden seleccionar en el formulario para precargar datos
+ */
+
+export interface RutaPredefinida {
+  id: string;
+  nombre: string;
+  lugar: string;
+  descripcion: string;
+  distancia?: string;
+  dificultad?: 'fácil' | 'moderada' | 'difícil';
+  plantilla?: string;
+}
+
+export const rutasPredefinidas: RutaPredefinida[] = [
+  {
+    id: 'cares',
+    nombre: 'Ruta del Cares',
+    lugar: 'Picos de Europa',
+    descripcion: 'Espectacular ruta por la garganta del Cares con vistas impresionantes',
+    distancia: '12 km',
+    dificultad: 'moderada',
+    plantilla: 'template1'
+  },
+  {
+    id: 'covadonga',
+    nombre: 'Lagos de Covadonga',
+    lugar: 'Asturias',
+    descripcion: 'Ascenso a los míticos lagos con paisajes de montaña',
+    distancia: '25 km',
+    dificultad: 'difícil',
+    plantilla: 'template1'
+  },
+  {
+    id: 'naranjo',
+    nombre: 'Naranjo de Bulnes',
+    lugar: 'Picos de Europa',
+    descripcion: 'Ruta hasta el emblemático Naranjo de Bulnes',
+    distancia: '18 km',
+    dificultad: 'difícil',
+    plantilla: 'template1'
+  },
+  {
+    id: 'senda-costera',
+    nombre: 'Senda Costera',
+    lugar: 'Costa Asturiana',
+    descripcion: 'Ruta panorámica por la costa con vistas al Cantábrico',
+    distancia: '30 km',
+    dificultad: 'fácil',
+    plantilla: 'template2'
+  },
+  {
+    id: 'puerto-pajares',
+    nombre: 'Puerto de Pajares',
+    lugar: 'León - Asturias',
+    descripcion: 'Clásico puerto de montaña con alto desnivel',
+    distancia: '35 km',
+    dificultad: 'difícil',
+    plantilla: 'template1'
+  },
+  {
+    id: 'ruta-urbana',
+    nombre: 'Ruta Urbana',
+    lugar: 'Centro Ciudad',
+    descripcion: 'Paseo urbano por la ciudad y sus alrededores',
+    distancia: '15 km',
+    dificultad: 'fácil',
+    plantilla: 'template3'
+  }
+];


### PR DESCRIPTION
…e datos

- Nuevo selector opcional al inicio del formulario
- 6 rutas predefinidas (montaña, costa, urbanas)
- Precarga automática de lugar, descripción, distancia, dificultad y plantilla
- Feedback visual al seleccionar una ruta
- Configuración centralizada en src/lib/rutasPredefinidas.ts
- Documentación completa en RUTAS-PREDEFINIDAS.md